### PR TITLE
ci: sync workflows from central-workflows [skip ci]

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout rule repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0


### PR DESCRIPTION
This PR syncs workflows from the central-workflows repository.

Signed-off-by: Justus-at-Tazama <Justus-at-Tazama@users.noreply.github.com>