### PR TITLE
fix: bump fast-uri to 3.1.5 (CVE-2026-18446)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4995,9 +4995,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
       "eslint --fix",
       "prettier --write"
     ]
+  },
+  "overrides": {
+    "fast-uri": "3.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- Bump transitive `fast-uri` to **3.1.5** to address [CVE-2026-18446](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) / GHSA-7p8r-x3mc-p8w7.
- Targets `dev` (not `main`).

## Test plan
- [ ] CI green on this PR
- [ ] Confirm `package-lock.json` resolves `fast-uri@3.1.5`
- [ ] No unintended `package.json` dependency changes (override only if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to use `fast-uri` version 3.1.5 for improved consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->